### PR TITLE
chore: add .DS_Store to .gitignore and remove existing .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ google-services.json
 
 # Android Profiling
 *.hprof.DS_Store
+
+# macOS Finder files
+.DS_Store


### PR DESCRIPTION
# chore: add .DS_Store to .gitignore and remove existing .DS_Store files

- Added `.DS_Store` to the `.gitignore` file to prevent macOS system files from being tracked.
- Removed all existing `.DS_Store` files from the repository.